### PR TITLE
Add local m2 to let us zip & share the repo standalone

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,4 +12,5 @@ pom.xml.asc
 .setup.sh
 profiles.clj
 .idea
+.m2-for-inclojure
 *.iml

--- a/project.clj
+++ b/project.clj
@@ -5,6 +5,7 @@
             :url "https://opensource.org/licenses/MIT"}
   ;; Requirements: Java 8 or higher (recommended: Java 8 or Java 11)
   :dependencies [[org.clojure/clojure "1.10.0"]]
+  :local-repo ".m2-for-inclojure"
   :profiles {:dev {:dependencies [[org.clojure/data.json "0.2.6"]
                                   [enlive "1.1.6"]
                                   [rewrite-clj "0.6.1"]]}})


### PR DESCRIPTION
With a project-local .m2, we can share workshop deps cleanly without
having to worry about leaking our own ~/.m2 which may have
proprietary or "production" jars.

With this change we can simply execute lein deps, and zip the entire
project so it becomes shareable standalone.

Not sure if this will work for Windows users, but at least they will
have the deps, and can copy them into whatever local m2 location works
for them.